### PR TITLE
Update PlcCHAR.java add Character type check to of method

### DIFF
--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/values/PlcCHAR.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/values/PlcCHAR.java
@@ -53,7 +53,9 @@ public class PlcCHAR extends PlcIECValue<Short> {
             return new PlcCHAR((BigInteger) value);
         } else if (value instanceof BigDecimal) {
             return new PlcCHAR((BigDecimal) value);
-        } else {
+        } else if(value instanceof Character){
+            return new PlcCHAR((Character) value)
+        }else {
             return new PlcCHAR((String) value);
         }
     }


### PR DESCRIPTION
As the API uses the of method to get the PlcCHAR object passing a char to API methods lead to errors, because internally the of method was used convert the passed object.